### PR TITLE
fix turbopages.org

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,9 +14,9 @@
     "256": "assets/icon_256.png"
   },
   "permissions": [
-    "https://yandex.ru/turbo/*",
     "webRequest",
-    "webRequestBlocking"
+    "webRequestBlocking",
+    "https://*.turbopages.org/*"
   ],
   "background": {
     "scripts": [

--- a/scripts/redirector.js
+++ b/scripts/redirector.js
@@ -14,7 +14,10 @@ var browserapp = (typeof browser !== 'undefined') ? browser : chrome;
 function turbo_redirector(requestDetails)
 {
   var turbo = new URL(requestDetails.url);
-  var redirection = turbo.pathname.replace(/^\/turbo\/s\//, 'https://').replace(/^\/turbo\//, 'https://').replace(/\/s\//, '\/');
+  var redirection = turbo.pathname.replace(/^\/turbo\/s\//, 'https://')
+                                      .replace(/^\/turbo\//, 'https://')
+                                      .replace(/\/s\//, '\/')
+                                      .replace(/^\//, 'https://');
   return {
     redirectUrl: redirection
   };
@@ -24,7 +27,7 @@ browserapp.webRequest.onBeforeRequest.addListener(
   turbo_redirector,
   {
     urls: [
-      'https://yandex.ru/turbo/*'
+      'https://*.turbopages.org/*'
     ]
   },
   ["blocking"]


### PR DESCRIPTION
яндекс перекатил свою срань на страницы вида

https://playboyrussia-com.turbopages.org/turbo/playboyrussia.com/s/faqty/kak-pravilno-paritsya-v-bane-s-venikom-podrobnoe-rukovodstvo-127991/

https://playboyrussia-com.turbopages.org/playboyrussia.com/s/faqty/kak-pravilno-paritsya-v-bane-s-venikom-podrobnoe-rukovodstvo-127991/